### PR TITLE
✨ Add ISO locale format support

### DIFF
--- a/.changeset/iso-locale-format.md
+++ b/.changeset/iso-locale-format.md
@@ -1,0 +1,10 @@
+---
+"@deegitalbe/laravel-trustup-io-translations-loader": minor
+---
+
+Add ISO locale format support
+
+- New `locale_format` config (`TRUSTUP_IO_TRANSLATIONS_LOCALE_FORMAT`), backed by the `LocaleFormat` enum (`service` default, `iso`).
+- In `iso` mode the loader maps an ISO language-country app locale (`fr-BE`) to the TrustUp.io country-language locale (`be-fr`) at lookup time, deriving the correspondence from the locales the API already exposes (`language` + `country`). No hardcoded map.
+- The cached/stored translation bundle is never rewritten: only the lookup key is converted, so a bundle cached by a `service`-mode consumer stays compatible. Unmapped locales pass through untouched.
+- Default `service` mode preserves the previous behaviour.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ $laravelTrustupIoTranslationsLoader = new Deegitalbe\LaravelTrustupIoTranslation
 echo $laravelTrustupIoTranslationsLoader->echoPhrase('Hello, Deegitalbe!');
 ```
 
+### Locale format (ISO applications)
+
+TrustUp.io keys translations by country-language (`be-fr`). If your app uses ISO
+language-country locales (`fr-BE`), enable the conversion:
+
+```env
+TRUSTUP_IO_TRANSLATIONS_LOCALE_FORMAT=iso
+```
+
+The loader converts the app locale to the TrustUp.io locale at lookup time (it
+only changes the lookup key, never the cached bundle). Default `service` keeps
+the locale as-is.
+
 ## Testing
 
 ```bash

--- a/config/trustup-io-translations-loader.php
+++ b/config/trustup-io-translations-loader.php
@@ -1,5 +1,7 @@
 <?php
 
+use Deegitalbe\LaravelTrustupIoTranslationsLoader\Enums\LocaleFormat;
+
 return [
 
     /**
@@ -12,6 +14,15 @@ return [
      * It needs to match the value set on translations.trustup.io.
      */
     'app_name' => env('TRUSTUP_IO_TRANSLATIONS_APP_NAME'),
+
+    /**
+     * Locale format of the application.
+     *
+     * "iso" maps an ISO app locale ("fr-BE") to the TrustUp.io locale ("be-fr")
+     * at lookup time only; the cached bundle stays keyed by the service locale.
+     * "service" (default) uses the locale as-is.
+     */
+    'locale_format' => env('TRUSTUP_IO_TRANSLATIONS_LOCALE_FORMAT', LocaleFormat::Service->value),
 
     /**
      * Cache settings.

--- a/src/Enums/LocaleFormat.php
+++ b/src/Enums/LocaleFormat.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Deegitalbe\LaravelTrustupIoTranslationsLoader\Enums;
+
+enum LocaleFormat: string
+{
+    /** App locale is a TrustUp.io locale ("be-fr"), used as-is. */
+    case Service = 'service';
+
+    /** App locale is ISO ("fr-BE"), converted to the TrustUp.io locale. */
+    case Iso = 'iso';
+
+    public static function fromConfig(): self
+    {
+        return self::tryFrom((string) config('trustup-io-translations-loader.locale_format'))
+            ?? self::Service;
+    }
+}

--- a/src/LaravelTrustupIoLocales.php
+++ b/src/LaravelTrustupIoLocales.php
@@ -53,4 +53,44 @@ class LaravelTrustupIoLocales
         return $this->getLocales()->where('locale', $locale)->first();
     }
 
+    /**
+     * Convert an ISO locale ("fr-BE") to the TrustUp.io locale ("be-fr").
+     * Unmapped locales pass through unchanged so a new locale never crashes
+     * the loader before the map is updated.
+     */
+    public function toServiceLocale(string $isoLocale): string
+    {
+        [$language, $country] = array_pad(explode('-', $isoLocale, 2), 2, '');
+
+        return $this->getIsoToServiceMap()[$this->isoKey($language, $country)] ?? $isoLocale;
+    }
+
+    /** Build the canonical ISO key: lowercase language, uppercase country ("fr-BE"). */
+    protected function isoKey(string $language, string $country): string
+    {
+        return strtolower($language).'-'.strtoupper($country);
+    }
+
+    /**
+     * Derived from getLocales() on each call so it never outlives the locale
+     * list it maps (getLocales() owns the caching).
+     *
+     * @return array<string, string>
+     */
+    protected function getIsoToServiceMap(): array
+    {
+        $map = [];
+
+        foreach ($this->getLocales() as $locale) {
+            // Tolerate locales missing fields if the API schema drifts.
+            if (! isset($locale->language, $locale->country, $locale->locale)) {
+                continue;
+            }
+
+            $map[$this->isoKey($locale->language, $locale->country)] = $locale->locale;
+        }
+
+        return $map;
+    }
+
 }

--- a/src/LaravelTrustupIoTranslationsLoader.php
+++ b/src/LaravelTrustupIoTranslationsLoader.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Translation\FileLoader;
+use Deegitalbe\LaravelTrustupIoTranslationsLoader\Enums\LocaleFormat;
 use Deegitalbe\LaravelTrustupIoTranslationsLoader\LaravelTrustupIoLocales;
 
 class LaravelTrustupIoTranslationsLoader extends FileLoader
@@ -20,10 +21,25 @@ class LaravelTrustupIoTranslationsLoader extends FileLoader
     {
         $translations = parent::loadPaths($paths, $locale, $group);
 
-        if ( $this->getTranslations() && isset($this->getTranslations()[$locale][$group]) ) {
-            $translations = array_merge($translations, $this->getTranslations()[$locale][$group]);
+        $remoteLocale = $this->resolveRemoteLocale($locale);
+
+        if ( $this->getTranslations() && isset($this->getTranslations()[$remoteLocale][$group]) ) {
+            $translations = array_merge($translations, $this->getTranslations()[$remoteLocale][$group]);
         }
 
         return $translations;
+    }
+
+    /**
+     * Resolve the bundle lookup key. Only the key is converted, never the
+     * stored bundle, so a bundle cached in either mode stays compatible.
+     */
+    protected function resolveRemoteLocale(string $locale): string
+    {
+        if ( LocaleFormat::fromConfig() !== LocaleFormat::Iso ) {
+            return $locale;
+        }
+
+        return app(LaravelTrustupIoLocales::class)->toServiceLocale($locale);
     }
 }

--- a/tests/IsoLocaleFormatTest.php
+++ b/tests/IsoLocaleFormatTest.php
@@ -1,0 +1,169 @@
+<?php
+
+use Deegitalbe\LaravelTrustupIoTranslationsLoader\Enums\LocaleFormat;
+use Deegitalbe\LaravelTrustupIoTranslationsLoader\LaravelTrustupIoLocales;
+use Deegitalbe\LaravelTrustupIoTranslationsLoader\LaravelTrustupIoTranslations;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+function fakeTranslationsAndLocales(array $translations, array $locales): void
+{
+    $base = config('trustup-io-translations-loader.url');
+    $appName = config('trustup-io-translations-loader.app_name');
+
+    Http::fake([
+        "{$base}/{$appName}/translations.json" => Http::response($translations, 200),
+        "{$base}/locales" => Http::response($locales, 200),
+    ]);
+}
+
+/** Service locales as exposed by /locales: keyed country-language, with language + country split. */
+function serviceLocales(): array
+{
+    return [
+        ['locale' => 'be-fr', 'language' => 'fr', 'country' => 'be'],
+        ['locale' => 'be-nl', 'language' => 'nl', 'country' => 'be'],
+        ['locale' => 'be-en', 'language' => 'en', 'country' => 'be'],
+    ];
+}
+
+/** Translation bundle keyed by the service locale (be-fr), never rewritten. */
+function serviceBundle(): array
+{
+    return [
+        'be-fr' => ['messages' => ['welcome' => 'Bienvenue']],
+        'be-nl' => ['messages' => ['welcome' => 'Welkom']],
+    ];
+}
+
+beforeEach(function () {
+    config()->set('trustup-io-translations-loader.url', 'https://translations.trustup.io');
+    config()->set('trustup-io-translations-loader.app_name', 'test-app');
+    config()->set('trustup-io-translations-loader.cache.enabled', false);
+    config()->set('trustup-io-translations-loader.cache.key', 'trustup-io-translations');
+    config()->set('trustup-io-translations-loader.cache.duration', 86400);
+    config()->set('trustup-io-translations-loader.disk.enabled', false);
+    config()->set('trustup-io-translations-loader.disk.name', 'local');
+    config()->set('trustup-io-translations-loader.disk.file_name', 'trustup-io-translations');
+    config()->set('trustup-io-translations-loader.disk.duration', 86400);
+
+    Storage::fake('local');
+    Cache::flush();
+});
+
+it('resolves an ISO app locale against the service-keyed bundle when locale_format is iso', function () {
+    config()->set('trustup-io-translations-loader.locale_format', LocaleFormat::Iso->value);
+    fakeTranslationsAndLocales(serviceBundle(), serviceLocales());
+
+    app()->instance(LaravelTrustupIoTranslations::class, new LaravelTrustupIoTranslations);
+    app()->instance(LaravelTrustupIoLocales::class, new LaravelTrustupIoLocales);
+
+    app()->setLocale('fr-BE');
+
+    expect(trans('messages.welcome'))->toBe('Bienvenue');
+});
+
+it('keeps the raw app locale when locale_format is service (default behaviour)', function () {
+    config()->set('trustup-io-translations-loader.locale_format', LocaleFormat::Service->value);
+    fakeTranslationsAndLocales(serviceBundle(), serviceLocales());
+
+    app()->instance(LaravelTrustupIoTranslations::class, new LaravelTrustupIoTranslations);
+    app()->instance(LaravelTrustupIoLocales::class, new LaravelTrustupIoLocales);
+
+    app()->setLocale('be-fr');
+
+    expect(trans('messages.welcome'))->toBe('Bienvenue');
+});
+
+it('does not resolve an ISO locale in service mode (no implicit conversion)', function () {
+    config()->set('trustup-io-translations-loader.locale_format', LocaleFormat::Service->value);
+    fakeTranslationsAndLocales(serviceBundle(), serviceLocales());
+
+    app()->instance(LaravelTrustupIoTranslations::class, new LaravelTrustupIoTranslations);
+    app()->instance(LaravelTrustupIoLocales::class, new LaravelTrustupIoLocales);
+
+    app()->setLocale('fr-BE');
+
+    expect(trans('messages.welcome'))->toBe('messages.welcome');
+});
+
+it('leaves an unmapped ISO locale untouched without crashing', function () {
+    config()->set('trustup-io-translations-loader.locale_format', LocaleFormat::Iso->value);
+    fakeTranslationsAndLocales(serviceBundle(), serviceLocales());
+
+    app()->instance(LaravelTrustupIoTranslations::class, new LaravelTrustupIoTranslations);
+    app()->instance(LaravelTrustupIoLocales::class, new LaravelTrustupIoLocales);
+
+    app()->setLocale('es-ES');
+
+    expect(trans('messages.welcome'))->toBe('messages.welcome');
+});
+
+it('resolves an ISO locale regardless of its casing', function (string $appLocale) {
+    config()->set('trustup-io-translations-loader.locale_format', LocaleFormat::Iso->value);
+    fakeTranslationsAndLocales(serviceBundle(), serviceLocales());
+
+    app()->instance(LaravelTrustupIoTranslations::class, new LaravelTrustupIoTranslations);
+    app()->instance(LaravelTrustupIoLocales::class, new LaravelTrustupIoLocales);
+
+    app()->setLocale($appLocale);
+
+    expect(trans('messages.welcome'))->toBe('Bienvenue');
+})->with(['fr-BE', 'fr-be', 'FR-BE', 'FR-be']);
+
+it('passes through when the locales API returns an empty list', function () {
+    config()->set('trustup-io-translations-loader.locale_format', LocaleFormat::Iso->value);
+    fakeTranslationsAndLocales(serviceBundle(), []);
+
+    app()->instance(LaravelTrustupIoTranslations::class, new LaravelTrustupIoTranslations);
+    app()->instance(LaravelTrustupIoLocales::class, new LaravelTrustupIoLocales);
+
+    app()->setLocale('fr-BE');
+
+    expect(trans('messages.welcome'))->toBe('messages.welcome');
+});
+
+it('skips malformed locale entries missing required fields', function () {
+    config()->set('trustup-io-translations-loader.locale_format', LocaleFormat::Iso->value);
+    fakeTranslationsAndLocales(serviceBundle(), [
+        ['language' => 'fr'], // missing country + locale
+        ['locale' => 'be-fr', 'language' => 'fr', 'country' => 'be'],
+    ]);
+
+    app()->instance(LaravelTrustupIoTranslations::class, new LaravelTrustupIoTranslations);
+    app()->instance(LaravelTrustupIoLocales::class, new LaravelTrustupIoLocales);
+
+    app()->setLocale('fr-BE');
+
+    expect(trans('messages.welcome'))->toBe('Bienvenue');
+});
+
+it('does not rewrite the stored bundle: it stays keyed by the service locale', function () {
+    config()->set('trustup-io-translations-loader.locale_format', LocaleFormat::Iso->value);
+    fakeTranslationsAndLocales(serviceBundle(), serviceLocales());
+
+    $translations = new LaravelTrustupIoTranslations;
+    app()->instance(LaravelTrustupIoTranslations::class, $translations);
+    app()->instance(LaravelTrustupIoLocales::class, new LaravelTrustupIoLocales);
+
+    app()->setLocale('fr-BE');
+    trans('messages.welcome');
+
+    expect($translations->get())->toBe(serviceBundle());
+});
+
+it('reads an ISO locale against a bundle stored under the service locale', function () {
+    config()->set('trustup-io-translations-loader.locale_format', LocaleFormat::Iso->value);
+
+    $translations = new LaravelTrustupIoTranslations;
+    $translations->getUnitTestsStorage()->put('translations_tests.json', json_encode(serviceBundle()));
+    app()->instance(LaravelTrustupIoTranslations::class, $translations);
+
+    Http::fake(['https://translations.trustup.io/locales' => Http::response(serviceLocales(), 200)]);
+    app()->instance(LaravelTrustupIoLocales::class, new LaravelTrustupIoLocales);
+
+    app()->setLocale('fr-BE');
+
+    expect(trans('messages.welcome'))->toBe('Bienvenue');
+});

--- a/tests/LocaleFormatTest.php
+++ b/tests/LocaleFormatTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Deegitalbe\LaravelTrustupIoTranslationsLoader\Enums\LocaleFormat;
+
+it('resolves the configured locale format from config', function () {
+    config()->set('trustup-io-translations-loader.locale_format', LocaleFormat::Iso->value);
+
+    expect(LocaleFormat::fromConfig())->toBe(LocaleFormat::Iso);
+});
+
+it('falls back to service when the configured value is unknown', function () {
+    config()->set('trustup-io-translations-loader.locale_format', 'nonsense');
+
+    expect(LocaleFormat::fromConfig())->toBe(LocaleFormat::Service);
+});
+
+it('falls back to service when the config value is null', function () {
+    config()->set('trustup-io-translations-loader.locale_format', null);
+
+    expect(LocaleFormat::fromConfig())->toBe(LocaleFormat::Service);
+});


### PR DESCRIPTION
## Why

TrustUp.io keys translations by country-language (`be-fr`). Applications running on ISO language-country locales (`fr-BE`) silently failed to resolve them: the lookup in `loadPaths` never matched the bundle keys.

## What

- New `locale_format` config (`TRUSTUP_IO_TRANSLATIONS_LOCALE_FORMAT`), backed by a `LocaleFormat` enum (`service` default, `iso`).
- In `iso` mode the loader maps the app locale to the TrustUp.io locale at lookup time, deriving the correspondence from the locales the API already exposes (`language` + `country`). No hardcoded table.
- Only the lookup key is converted; the cached/stored bundle is never rewritten, so a bundle cached by a `service`-mode consumer stays compatible.
- Locale matching is case-insensitive; unmapped and malformed locales pass through untouched.
- Default `service` mode preserves the previous behaviour.

## Notes

- Changeset included (`minor`).
- 29 tests passing (case variants, empty/malformed locales API, cached-bundle compatibility, service-mode regression).