### PR TITLE
♻️ Auto-register the remote translation loader

### DIFF
--- a/.changeset/auto-register-loader.md
+++ b/.changeset/auto-register-loader.md
@@ -1,0 +1,12 @@
+---
+"@deegitalbe/laravel-trustup-io-translations-loader": minor
+---
+
+Auto-register the remote translation loader
+
+The remote loader is now installed by the auto-discovered service provider via
+`extend('translation.loader')`, which wins regardless of provider order. Consumers
+no longer need to register `TrustUpTranslationServiceProvider` manually.
+
+`TrustUpTranslationServiceProvider` is kept as a deprecated no-op so existing
+manual registrations keep working; it can be removed from consumer provider lists.

--- a/src/LaravelTrustupIoTranslationsLoaderServiceProvider.php
+++ b/src/LaravelTrustupIoTranslationsLoaderServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Deegitalbe\LaravelTrustupIoTranslationsLoader;
 
+use Illuminate\Translation\FileLoader;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Deegitalbe\LaravelTrustupIoTranslationsLoader\Commands\LaravelTrustupIoTranslationsLoaderCommand;
@@ -25,5 +26,19 @@ class LaravelTrustupIoTranslationsLoaderServiceProvider extends PackageServicePr
             ->hasRoute('webhooks');
 
         require_once __DIR__.'/helpers.php';
+    }
+
+    /**
+     * Replace Laravel's FileLoader with the remote loader. Laravel binds its own
+     * translation.loader from a deferred provider that loads after this package,
+     * so a plain singleton would be overwritten. extend() runs at resolution
+     * time instead and returns our loader regardless of binding order, reusing
+     * the lang paths the framework loader already resolved.
+     */
+    public function packageRegistered(): void
+    {
+        $this->app->extend('translation.loader', function (FileLoader $loader, $app) {
+            return new LaravelTrustupIoTranslationsLoader($app['files'], $loader->paths());
+        });
     }
 }

--- a/src/TrustUpTranslationServiceProvider.php
+++ b/src/TrustUpTranslationServiceProvider.php
@@ -2,24 +2,15 @@
 
 namespace Deegitalbe\LaravelTrustupIoTranslationsLoader;
 
-use Illuminate\Translation\FileLoader;
-use Illuminate\Translation\TranslationServiceProvider as IlluminateTranslationServiceProvider;
+use Illuminate\Support\ServiceProvider;
 
-class TrustUpTranslationServiceProvider extends IlluminateTranslationServiceProvider
+/**
+ * @deprecated The remote translation loader is now registered automatically by
+ * the auto-discovered LaravelTrustupIoTranslationsLoaderServiceProvider. This
+ * provider is a no-op kept only so existing manual registrations keep working;
+ * remove it from your providers list.
+ */
+class TrustUpTranslationServiceProvider extends ServiceProvider
 {
-
-    /**
-     * Register the translation line loader. This method registers a
-     * `LaravelTrustupIoTranslationsLoader` instead of a simple `FileLoader` as the
-     * applications `translation.loader` instance.
-     */
-    protected function registerLoader()
-    {
-        $this->app->singleton('translation.loader', function ($app) {
-            $frameworkLangPath = dirname((new \ReflectionClass(FileLoader::class))->getFileName()) . '/lang';
-
-            return new LaravelTrustupIoTranslationsLoader($app['files'], [$frameworkLangPath, $app['path.lang']]);
-        });
-    }
-
+    public function register(): void {}
 }

--- a/tests/LoaderRegistrationTest.php
+++ b/tests/LoaderRegistrationTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use Deegitalbe\LaravelTrustupIoTranslationsLoader\LaravelTrustupIoTranslationsLoader;
+use Deegitalbe\LaravelTrustupIoTranslationsLoader\TrustUpTranslationServiceProvider;
+
+it('binds the custom translation loader from the auto-discovered provider alone', function () {
+    expect(app('translation.loader'))->toBeInstanceOf(LaravelTrustupIoTranslationsLoader::class);
+});
+
+it('still binds the custom loader when the deprecated provider is also registered', function () {
+    app()->register(TrustUpTranslationServiceProvider::class);
+
+    expect(app('translation.loader'))->toBeInstanceOf(LaravelTrustupIoTranslationsLoader::class);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,7 +5,6 @@ namespace Deegitalbe\LaravelTrustupIoTranslationsLoader\Tests;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Deegitalbe\LaravelTrustupIoTranslationsLoader\LaravelTrustupIoTranslationsLoaderServiceProvider;
-use Deegitalbe\LaravelTrustupIoTranslationsLoader\TrustUpTranslationServiceProvider;
 
 class TestCase extends Orchestra
 {
@@ -22,7 +21,6 @@ class TestCase extends Orchestra
     {
         return [
             LaravelTrustupIoTranslationsLoaderServiceProvider::class,
-            TrustUpTranslationServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
## Why

The remote loader was only installed by `TrustUpTranslationServiceProvider`, which consumers had to register manually — and in the right order relative to the framework's deferred `TranslationServiceProvider`. Easy to get wrong, easy to forget.

## What

- The auto-discovered `LaravelTrustupIoTranslationsLoaderServiceProvider` now swaps `translation.loader` itself, in `packageRegistered()`, via `extend()`. `extend()` runs at resolution time, so it wins regardless of provider order (a plain `singleton()` was overwritten by the framework's deferred provider).
- The extender reuses the lang paths the framework loader already resolved (`$loader->paths()`) instead of re-deriving them through reflection.
- `TrustUpTranslationServiceProvider` becomes a deprecated no-op so existing manual registrations keep working; consumers can drop it from their providers list.

## Result

`composer require` is enough — no manual provider registration.

## Notes

- Changeset included (`minor`).
- 31 tests passing, including the dual-registration migration path (deprecated provider + auto-discovered provider together still bind our loader).