### PR TITLE
✨ Add tests.fetch flag to keep the loader offline during tests

### DIFF
--- a/.changeset/configurable-test-offline.md
+++ b/.changeset/configurable-test-offline.md
@@ -1,0 +1,13 @@
+---
+"@deegitalbe/laravel-trustup-io-translations-loader": minor
+---
+
+Add a tests.fetch flag to keep the loader offline during tests
+
+`tests.fetch` (env `TRUSTUP_IO_TRANSLATIONS_TESTS_FETCH`, default `true`) lets a
+consumer disable every network call the loader makes during tests. When set to
+`false`, translations resolve to an empty bundle and locales fall back to a
+built-in default set without hitting the API, so a consumer using the iso locale
+format keeps a working `fr-BE` -> `be-fr` conversion offline and no longer
+triggers stray requests in its own test suite. Tests that need remote
+translations bind their own instances.

--- a/config/trustup-io-translations-loader.php
+++ b/config/trustup-io-translations-loader.php
@@ -61,14 +61,15 @@ return [
 
     /**
      * Tests settings.
-     * When unit tests are running, the package will only load translations
-     * once then store them in a .json file to prevent hitting the API
-     * too much. We do not leverage the cache for this as it can
-     * be disabled during some or all tests.
-     * 
-     * You can customize the storage disk if you want.
+     * When unit tests are running, the package loads translations once then
+     * stores them in a .json file to avoid hitting the API too much.
+     *
+     * Set 'fetch' to false to keep the loader fully offline during tests: it
+     * then resolves no translations and no locales without any network call.
+     * Tests that need remote data bind their own instances instead.
      */
     'tests' => [
+        'fetch' => env('TRUSTUP_IO_TRANSLATIONS_TESTS_FETCH', true),
         'storage_disk' => env('TRUSTUP_IO_TRANSLATIONS_TESTS_STORAGE_DISK', 'local'),
     ],
 ];

--- a/src/LaravelTrustupIoLocales.php
+++ b/src/LaravelTrustupIoLocales.php
@@ -18,11 +18,33 @@ class LaravelTrustupIoLocales
             return $this->locales;
         }
 
+        if ( config('trustup-io-translations-loader.tests.fetch', true) === false ) {
+            return $this->locales = $this->defaultLocales();
+        }
+
         if ( Cache::has('trustup-io-translations-locales') ) {
             return $this->locales = Cache::get('trustup-io-translations-locales');
         }
 
         return $this->locales = $this->fetch();
+    }
+
+    /**
+     * Locales used during tests when fetching is disabled, so the iso locale
+     * conversion still works offline. Mirrors the locales the API exposes.
+     */
+    protected function defaultLocales(): Collection
+    {
+        return collect([
+            ['locale' => 'be-fr', 'language' => 'fr', 'country' => 'be'],
+            ['locale' => 'be-nl', 'language' => 'nl', 'country' => 'be'],
+            ['locale' => 'be-en', 'language' => 'en', 'country' => 'be'],
+            ['locale' => 'be-de', 'language' => 'de', 'country' => 'be'],
+            ['locale' => 'fr-fr', 'language' => 'fr', 'country' => 'fr'],
+            ['locale' => 'fr-en', 'language' => 'en', 'country' => 'fr'],
+            ['locale' => 'nl-nl', 'language' => 'nl', 'country' => 'nl'],
+            ['locale' => 'nl-en', 'language' => 'en', 'country' => 'nl'],
+        ])->map(fn (array $locale): Fluent => new Fluent($locale));
     }
 
     public function fetch(): Collection

--- a/src/LaravelTrustupIoTranslations.php
+++ b/src/LaravelTrustupIoTranslations.php
@@ -151,6 +151,11 @@ class LaravelTrustupIoTranslations
 
     public function setForUnitTests(): void
     {
+        if ( config('trustup-io-translations-loader.tests.fetch', true) === false ) {
+            $this->translations = [];
+            return;
+        }
+
         if ( $this->getUnitTestsStorage()->exists('translations_tests.json') ) {
             $this->translations = json_decode($this->getUnitTestsStorage()->get('translations_tests.json'), true);
             return;

--- a/tests/OfflineTestsTest.php
+++ b/tests/OfflineTestsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Deegitalbe\LaravelTrustupIoTranslationsLoader\LaravelTrustupIoLocales;
+use Deegitalbe\LaravelTrustupIoTranslationsLoader\LaravelTrustupIoTranslations;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    config()->set('trustup-io-translations-loader.url', 'https://translations.trustup.io');
+    config()->set('trustup-io-translations-loader.app_name', 'test-app');
+    config()->set('trustup-io-translations-loader.cache.enabled', false);
+    config()->set('trustup-io-translations-loader.disk.enabled', false);
+    Storage::fake('local');
+    Cache::flush();
+    Http::preventStrayRequests();
+});
+
+it('does not hit the API for translations when tests.fetch is false', function () {
+    config()->set('trustup-io-translations-loader.tests.fetch', false);
+    Http::fake();
+
+    $translations = new LaravelTrustupIoTranslations;
+
+    expect($translations->get())->toBe([]);
+    Http::assertNothingSent();
+});
+
+it('returns default locales without hitting the API when tests.fetch is false', function () {
+    config()->set('trustup-io-translations-loader.tests.fetch', false);
+    Http::fake();
+
+    $locales = new LaravelTrustupIoLocales;
+
+    expect($locales->getLocales())->not->toBeEmpty();
+    Http::assertNothingSent();
+});
+
+it('converts iso locales offline using the default locales when tests.fetch is false', function (string $iso, string $service) {
+    config()->set('trustup-io-translations-loader.tests.fetch', false);
+    Http::fake();
+
+    expect((new LaravelTrustupIoLocales)->toServiceLocale($iso))->toBe($service);
+    Http::assertNothingSent();
+})->with([
+    ['fr-BE', 'be-fr'],
+    ['nl-NL', 'nl-nl'],
+    ['en-FR', 'fr-en'],
+]);
+
+it('defaults to fetching when tests.fetch is absent (config not published)', function () {
+    config()->set('trustup-io-translations-loader.tests.fetch', null);
+    Http::fake([
+        'https://translations.trustup.io/test-app/translations.json' => Http::response(['be-fr' => []], 200),
+    ]);
+
+    (new LaravelTrustupIoTranslations)->get();
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/translations.json'));
+});
+
+it('still fetches when tests.fetch is true (default behaviour)', function () {
+    config()->set('trustup-io-translations-loader.tests.fetch', true);
+    Http::fake([
+        'https://translations.trustup.io/test-app/translations.json' => Http::response(['be-fr' => []], 200),
+    ]);
+
+    $translations = new LaravelTrustupIoTranslations;
+    $translations->get();
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/translations.json'));
+});


### PR DESCRIPTION
## Why

The iso locale format calls `/locales` to build its conversion map, on top of the translations endpoint. In a consumer test suite with stray-request protection, any `trans()` then triggers an unfaked network call — breaking tests that have nothing to do with translations.

## What

- `tests.fetch` config (env `TRUSTUP_IO_TRANSLATIONS_TESTS_FETCH`, default `true`) disables every network call the loader makes during tests.
- When `false`: translations resolve to an empty bundle, and locales fall back to a built-in default set (the locales the API exposes) so the `fr-BE` → `be-fr` conversion keeps working offline.
- Strict `=== false` against a `true` default: an unpublished config or absent key keeps the production fetch behaviour; only an explicit `false` opts into offline.

## Result

A consumer using the iso format can keep its whole suite offline with one env var, without losing locale conversion.

## Notes

- Changeset included (`minor`).
- 38 tests passing: offline translations + locales, offline iso conversion across multiple locales, and the default-fetch path when the flag is absent.